### PR TITLE
Fix spacing/formatting of brand logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Client library for use with PortoSpire Sites
 A free (LGPL3) client library for use with PortoSpire Sites to abstract various API usage to enable easier integrations.
 
-<a href="https://www.portospire.com/">Provided by PortoSpire 
+<a href="https://www.portospire.com/">Provided by PortoSpire<br />
     <img src="https://assets.portospire.com/psf/img/portospire%20header%20glow.svg" alt="PortoSpire - be seen" width="182" /></a>
 
 [Introduction](#introduction)


### PR DESCRIPTION
-- added forced line break between powered by PortoSpire and brand logo